### PR TITLE
add glue dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ VignetteBuilder: knitr
 Imports: 
     assertthat,
     dplyr,
+    glue,
     iNEXT,
     magrittr,
     purrr,


### PR DESCRIPTION
Add glue to DESCRIPTION under imports, used in assertthat msg argument to create nicer error messages (currently untested)

It probably would have been nicer to just use cli instead of assertthat + glue